### PR TITLE
Fix `propTypes` case-sensitivity

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -64,7 +64,7 @@ class Calendar extends Component {
   }
 }
 
-Calendar.PropTypes = {
+Calendar.propTypes = {
   startHour: PropTypes.string,
   endHour: PropTypes.string,
   dateFormat: PropTypes.string,

--- a/src/components/daily.js
+++ b/src/components/daily.js
@@ -199,7 +199,7 @@ DailyCalendar.defaultProps = {
   type: 'daily',
 }
 
-DailyCalendar.PropTypes = {
+DailyCalendar.propTypes = {
   startHour: PropTypes.string,
   endHour: PropTypes.string,
   rowHeight: PropTypes.number,

--- a/src/components/monthly.js
+++ b/src/components/monthly.js
@@ -95,7 +95,7 @@ MonthlyCalendar.childContextTypes = {
 }
 MonthlyCalendar.defaultProps = {start: new Date()}
 
-MonthlyCalendar.PropTypes = {
+MonthlyCalendar.propTypes = {
   rowHeight: PropTypes.number,
   start: PropTypes.instanceOf(Date),
   locale: PropTypes.object,

--- a/src/components/weekly.js
+++ b/src/components/weekly.js
@@ -247,7 +247,7 @@ WeeklyCalendar.childContextTypes = {
 
 WeeklyCalendar.defaultProps = {start: new Date(), showNow: false, type: 'weekly'}
 
-WeeklyCalendar.PropTypes = {
+WeeklyCalendar.propTypes = {
   startHour: PropTypes.string,
   endHour: PropTypes.string,
   showWeekend: PropTypes.bool,


### PR DESCRIPTION
Fixes
```
 Warning: Component t declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?
```